### PR TITLE
Exclude `storage` directory from RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
     - db/schema.rb
     - tmp/**/*
     - lib/tasks/import/*.rake
+    - storage/**/*
 
 #
 # Linters


### PR DESCRIPTION
Closes #85